### PR TITLE
Minor fixes to event-based methods

### DIFF
--- a/openquake/hazardlib/calc/gmf.py
+++ b/openquake/hazardlib/calc/gmf.py
@@ -24,7 +24,7 @@ import numpy
 import scipy.stats
 
 from openquake.hazardlib.const import StdDev
-from openquake.hazardlib.gsim.base import ContextMaker, GeotechContextMaker
+from openquake.hazardlib.gsim.base import ContextMaker #, GeotechContextMaker
 #from openquake.hazardlib.gsim.base import ContextMaker
 from openquake.hazardlib.gsim.multi import MultiGMPE
 from openquake.hazardlib.imt import from_string
@@ -209,34 +209,12 @@ class GeotechFieldComputer(GmfComputer):
                  truncation_level=None, correlation_model=None):
         """
         Note to ensure same inputs as GmfComputer, and are not actually used
-        in the function
+                in the function
         """
-        assert isinstance(cmaker, GeotechContextMaker)
-        if len(sitecol) == 0:
-            raise ValueError('No sites')
-        #elif len(imts) == 0:
-        #    raise ValueError('No IMTs')
-        elif len(cmaker.gsims) == 0:
-            raise ValueError('No GSIMs')
-        self.rupture = rupture
-        #self.imts = [from_string(imt) for imt in imts]
+        super().__init__(rupture, sitecol, imts, cmaker, truncation_level,
+                         correlation_model)
         self.cmaker = cmaker
-        self.gsims = sorted(cmaker.gsims)
-        self.imts = [imt in self.gsims[0].imts]
-        self.truncation_level = truncation_level
-        self.correlation_model = correlation_model
-        # `rupture` can be a high level rupture object containing a low
-        # level hazardlib rupture object as a .rupture attribute
-        if hasattr(rupture, 'rupture'):
-            rupture = rupture.rupture
-        try:
-            self.sctx, self.dctx = rupture.sctx, rupture.dctx
-        except AttributeError:
-            self.sctx, self.dctx = cmaker.make_contexts(sitecol, rupture)
-        self.sids = self.sctx.sids
-        self.sites = sitecol
-        if correlation_model:  # store the filtered sitecol
-            self.sites = sitecol.filtered(self.sids)
+        self.sitecol = sitecol
 
     def compute(self, gsim, num_events, seed=None):
         """
@@ -253,10 +231,38 @@ class GeotechFieldComputer(GmfComputer):
             numpy.random.seed(seed)
         # In this particular case the GSIMs are organised by IMT in the context
         # maker
-        return gsim.get_displacement_field(self.rupture, self.sites,
+        return gsim.get_displacement_field(self.rupture, self.sitecol,
                                            self.cmaker, num_events,
                                            self.truncation_level,
                                            self.correlation_model)
+#        #assert isinstance(cmaker, GeotechContextMaker)
+#        if len(sitecol) == 0:
+#            raise ValueError('No sites')
+#        elif len(imts) == 0:
+#            raise ValueError('No IMTs')
+#        elif len(cmaker.gsims) == 0:
+#            raise ValueError('No GSIMs')
+#        self.rupture = rupture
+#        #self.imts = [from_string(imt) for imt in imts]
+#        self.cmaker = cmaker
+#        self.gsims = sorted(cmaker.gsims)
+#        self.imts = [imt in self.gsims[0].imts]
+#        self.truncation_level = truncation_level
+#        self.correlation_model = correlation_model
+#        # `rupture` can be a high level rupture object containing a low
+#        # level hazardlib rupture object as a .rupture attribute
+#        if hasattr(rupture, 'rupture'):
+#            rupture = rupture.rupture
+#        try:
+#            self.sctx, self.dctx = rupture.sctx, rupture.dctx
+#        except AttributeError:
+#            self.sctx, self.dctx = cmaker.make_contexts(sitecol, rupture)
+#        self.sids = self.sctx.sids
+#        self.sites = sitecol
+#        if correlation_model:  # store the filtered sitecol
+#            self.sites = sitecol.filtered(self.sids)
+
+
 
 
 # this is not used in the engine; it is still useful for usage in IPython

--- a/openquake/hazardlib/gdem/base.py
+++ b/openquake/hazardlib/gdem/base.py
@@ -45,9 +45,11 @@ class GDEM(MultiGMPE):
     REQUIRES_DISTANCES = set()
     REQUIRES_RUPTURE_PARAMETERS = set(("mag",))
     REQUIRES_SITES_PARAMETERS = set()
+    IMT_ORDER = []
 
     def __init__(self, gsim_by_imt, truncation=6.0, nsample=100):
         super().__init__(gsim_by_imt)
+        self.imts = []
         for imt in self.gsim_by_imt:
             self.REQUIRES_SITES_PARAMETERS = (
                 self.REQUIRES_SITES_PARAMETERS |
@@ -57,7 +59,7 @@ class GDEM(MultiGMPE):
                 self.gsim_by_imt[imt].REQUIRES_RUPTURE_PARAMETERS)
             self.REQUIRES_DISTANCES = (self.REQUIRES_DISTANCES |
                 self.gsim_by_imt[imt].REQUIRES_DISTANCES)
-
+            self.imts.append(imt)
         # Geotechnical hazard requires the definition of an integral of
         # the expected displacement conditional upon the shaking at the surface
         # As this is integrated numerically we can pre-calculate the integral

--- a/openquake/hazardlib/gdem/scalar.py
+++ b/openquake/hazardlib/gdem/scalar.py
@@ -126,11 +126,11 @@ class SlopeDisplacementScalar(GDEM):
         """
         raise NotImplementedError("Not implemented for base class")
 
-    def _get_gmv_field_location(self, gmfs):
+    def _get_gmv_field_location(self):
         """
         Get the ground motion values needed for the field.
         """
-        req_imt = from_string(self.IMT_ORDER[0])
+        req_imt = self.IMT_ORDER[0]
         if not req_imt in self.imts:
             raise ValueError("%s requires calculation of %s "
                              "but not found in imts" %
@@ -149,7 +149,7 @@ class SlopeDisplacementScalar(GDEM):
         # Gets the ground motion fields
         gmf_loc = self._get_gmv_field_location()
         gmf_computer = GmfComputer(rupture, sitecol,
-                                   [str(imt) for imt in self.imts],
+                                   [str(imt) for IMT in self.IMT_ORDER],
                                    cmaker, truncation_level,
                                    correlation_model)
         gmfs = gmf_computer.compute(self.gmpe, num_events, seed=None)
@@ -167,13 +167,13 @@ class SlopeDisplacementScalar(GDEM):
         if not np.any(mask):
             # No displacement at any site - return zeros and the ground motion
             # fields
-            return displacement, gmfs
+            return displacement, gmfs, mask.astype(float)
 
         mean_disp, [stddevs] = self.get_displacement(sctx, rctx, dctx, gmv,
                                                      properties, mask)
         displacement[0][mask] = np.exp(mean_disp +
                                        np.random.normal(0., 1.) * stddevs)
-        return displacement, gmfs
+        return displacement, gmfs, mask.astype(float)
         
 
 class Jibson2007PGA(SlopeDisplacementScalar):


### PR DESCRIPTION
Suspending the GeotechContextMaker (hoping to avoid this in future) and minimizing the differences in the __init__ of the GeotechFieldComputer.

Orders of IMTs in the GDEM class replaced with strings, and needed for calculators to identify where in the GMFs the required IMT is.